### PR TITLE
Added jacoco support for groovy projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
   </parent>
 
   <artifactId>sonar-groovy-plugin</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>20130816.00.50</version>
   <packaging>sonar-plugin</packaging>
 
   <name>Sonar Groovy Plugin</name>
-  <description>Enables analysis of Groovy projects into Sonar.</description>
+  <description>Enables analysis of Groovy projects.</description>
   <url>http://docs.codehaus.org/display/SONAR/Groovy+Plugin</url>
   <inceptionYear>2010</inceptionYear>
   <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -51,12 +51,17 @@
   </issueManagement>
 
   <properties>
-    <sonar.version>3.0</sonar.version>
+    <sonar.version>3.5.1</sonar.version>
     <sonar.pluginName>Groovy</sonar.pluginName>
     <sonar.pluginClass>org.sonar.plugins.groovy.GroovyPlugin</sonar.pluginClass>
   </properties>
 
   <dependencies>
+    <dependency>
+        <groupId>org.codehaus.sonar-plugins.java</groupId>
+         <artifactId>sonar-java-plugin</artifactId>
+         <version>1.2</version>
+    </dependency>
     <dependency>
       <groupId>org.codehaus.sonar</groupId>
       <artifactId>sonar-plugin-api</artifactId>
@@ -64,21 +69,47 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.sonar</groupId>
+      <artifactId>sonar-batch</artifactId>
+      <version>${sonar.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.codehaus.sonar.plugins</groupId>
+        <artifactId>sonar-java-plugin</artifactId>
+        <version>3.2.1</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant</artifactId>
+        <version>1.8.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.sonar.plugins</groupId>
       <artifactId>sonar-surefire-plugin</artifactId>
-      <version>${sonar.version}</version>
+      <version>3.2.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.sonar.plugins</groupId>
       <artifactId>sonar-cobertura-plugin</artifactId>
-      <version>${sonar.version}</version>
+      <version>3.2.1</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.sonar.plugins</groupId>
+      <artifactId>sonar-jacoco-plugin</artifactId>
+      <version>3.2.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.jacoco</groupId>
+        <artifactId>org.jacoco.core</artifactId>
+        <version>0.6.2.201302030002</version>
     </dependency>
     <dependency>
       <groupId>org.codenarc</groupId>
       <artifactId>CodeNarc</artifactId>
-      <version>0.17</version>
+      <version>0.18.1</version>
       <exclusions>
         <exclusion>
           <groupId>log4j</groupId>

--- a/src/main/java/org/sonar/plugins/groovy/GroovyPlugin.java
+++ b/src/main/java/org/sonar/plugins/groovy/GroovyPlugin.java
@@ -36,14 +36,23 @@ import org.sonar.plugins.groovy.foundation.GroovyColorizerFormat;
 import org.sonar.plugins.groovy.foundation.GroovyCpdMapping;
 import org.sonar.plugins.groovy.foundation.GroovySourceImporter;
 import org.sonar.plugins.groovy.surefire.SurefireSensor;
+import org.sonar.plugins.groovy.jacoco.*;
 
 import java.util.List;
 
 @Properties({
   @Property(
     key = GroovyPlugin.CODENARC_REPORT_PATH,
-    name = "Report file",
+    name = "Codenarc Report file",
     description = "Path (absolute or relative) to CodeNarc XML report in case generation is not handle by the plugin.",
+    module = true,
+    project = true,
+    global = false
+  ),
+  @Property(
+    key = GroovyPlugin.JACOCO_REPORT_PATH,
+    name = "Jacoco Report file",
+    description = "Path (absolute or relative) to Jacoco EXEC report in case generation is not handle by the plugin.",
     module = true,
     project = true,
     global = false
@@ -51,6 +60,7 @@ import java.util.List;
 })
 public class GroovyPlugin extends SonarPlugin {
 
+  public static final String JACOCO_REPORT_PATH = "sonar.groovy.jacoco.reportPath";
   public static final String CODENARC_REPORT_PATH = "sonar.groovy.codenarc.reportPath";
 
   public List<?> getExtensions() {
@@ -73,6 +83,17 @@ public class GroovyPlugin extends SonarPlugin {
         // Cobertura
         CoberturaSensor.class,
         CoberturaMavenPluginHandler.class,
+
+        // jacoco
+        JacocoConfiguration.class,
+        JaCoCoAgentDownloader.class,
+        JacocoAntInitializer.class,
+        JacocoMavenInitializer.class,
+        JaCoCoMavenPluginHandler.class,
+        JaCoCoSensor.class,
+        JaCoCoItSensor.class,
+        JaCoCoOverallSensor.class,
+
         // Surefire
         SurefireSensor.class);
   }

--- a/src/main/java/org/sonar/plugins/groovy/GroovyPlugin.java
+++ b/src/main/java/org/sonar/plugins/groovy/GroovyPlugin.java
@@ -56,11 +56,21 @@ import java.util.List;
     module = true,
     project = true,
     global = false
+  ),
+    @Property(
+    key = GroovyPlugin.JACOCO_IT_REPORT_PATH,
+    name = "Jacoco Integration Test Report file",
+    description = "Path (absolute or relative) to Jacoco EXEC report in case generation is not handle by the plugin.",
+    module = true,
+    project = true,
+    global = false
   )
+
 })
 public class GroovyPlugin extends SonarPlugin {
 
   public static final String JACOCO_REPORT_PATH = "sonar.groovy.jacoco.reportPath";
+  public static final String JACOCO_IT_REPORT_PATH = "sonar.groovy.jacoco.reportPath";
   public static final String CODENARC_REPORT_PATH = "sonar.groovy.codenarc.reportPath";
 
   public List<?> getExtensions() {

--- a/src/main/java/org/sonar/plugins/groovy/GroovySensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/GroovySensor.java
@@ -41,6 +41,7 @@ import org.sonar.api.resources.ProjectFileSystem;
 import org.sonar.plugins.groovy.foundation.Groovy;
 import org.sonar.plugins.groovy.foundation.GroovyRecognizer;
 import org.sonar.plugins.groovy.gmetrics.CustomSourceAnalyzer;
+import org.sonar.plugins.groovy.jacoco.GroovyFile;
 import org.sonar.squid.measures.Metric;
 import org.sonar.squid.text.Source;
 
@@ -86,12 +87,12 @@ public class GroovySensor implements Sensor {
     for (Entry<File, Collection<ClassResultsNode>> entry : analyzer.getResultsByFile().asMap().entrySet()) {
       File file = entry.getKey();
       Collection<ClassResultsNode> results = entry.getValue();
-      org.sonar.api.resources.File sonarFile = org.sonar.api.resources.File.fromIOFile(file, project.getFileSystem().getSourceDirs());
+      GroovyFile sonarFile = GroovyFile.fromIOFile(file, project.getFileSystem().getSourceDirs(), false);
       processFile(context, sonarFile, results);
     }
   }
 
-  private void processFile(SensorContext context, org.sonar.api.resources.File sonarFile, Collection<ClassResultsNode> results) {
+  private void processFile(SensorContext context, GroovyFile sonarFile, Collection<ClassResultsNode> results) {
     double classes = 0;
     double methods = 0;
     double complexity = 0;
@@ -139,7 +140,7 @@ public class GroovySensor implements Sensor {
     for (File groovyFile : fileSystem.getSourceFiles(groovy)) {
       try {
         reader = new StringReader(FileUtils.readFileToString(groovyFile, fileSystem.getSourceCharset().name()));
-        org.sonar.api.resources.File resource = org.sonar.api.resources.File.fromIOFile(groovyFile, fileSystem.getSourceDirs());
+        GroovyFile resource = GroovyFile.fromIOFile(groovyFile, fileSystem.getSourceDirs(), false);
         Source source = new Source(reader, new GroovyRecognizer());
         packageList.add(new org.sonar.api.resources.Directory(resource.getParent().getKey()));
         sensorContext.saveMeasure(resource, CoreMetrics.LINES, (double) source.getMeasure(Metric.LINES));

--- a/src/main/java/org/sonar/plugins/groovy/cobertura/CoberturaMavenPluginHandler.java
+++ b/src/main/java/org/sonar/plugins/groovy/cobertura/CoberturaMavenPluginHandler.java
@@ -73,7 +73,7 @@ public class CoberturaMavenPluginHandler implements MavenPluginHandler {
       }
       coberturaPlugin.addParameter("instrumentation/excludes/exclude", pattern);
     }
-    coberturaPlugin.setParameter("maxmem", settings.getString(CoreProperties.COBERTURA_MAXMEM_PROPERTY));
+    coberturaPlugin.setParameter("maxmem", settings.getString("sonar.cobertura.maxmen"));
   }
 
 }

--- a/src/main/java/org/sonar/plugins/groovy/cobertura/CoberturaSensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/cobertura/CoberturaSensor.java
@@ -33,6 +33,7 @@ import org.sonar.api.resources.Resource;
 import org.sonar.plugins.cobertura.api.AbstractCoberturaParser;
 import org.sonar.plugins.cobertura.api.CoberturaUtils;
 import org.sonar.plugins.groovy.foundation.Groovy;
+import org.sonar.plugins.groovy.jacoco.GroovyFile;
 
 import java.io.File;
 
@@ -72,8 +73,8 @@ public class CoberturaSensor implements Sensor, DependsUponMavenPlugin, Coverage
   private static final AbstractCoberturaParser COBERTURA_PARSER = new AbstractCoberturaParser() {
     @Override
     protected Resource<?> getResource(String fileName) {
-      fileName = fileName.replace(".", "/") + ".groovy";
-      return new org.sonar.api.resources.File(fileName);
+      fileName = fileName.replace(".", "/");
+      return new GroovyFile(fileName);
     }
   };
 

--- a/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensor.java
@@ -39,6 +39,7 @@ import org.sonar.api.utils.SonarException;
 import org.sonar.plugins.groovy.GroovyPlugin;
 import org.sonar.plugins.groovy.codenarc.CodeNarcXMLParser.CodeNarcViolation;
 import org.sonar.plugins.groovy.foundation.Groovy;
+import org.sonar.plugins.groovy.jacoco.GroovyFile;
 
 import java.io.File;
 import java.io.IOException;
@@ -93,7 +94,7 @@ public class CodeNarcSensor implements Sensor {
             .withConfigKey(violation.getRuleName());
         Rule rule = ruleFinder.find(ruleQuery);
         if (rule != null) {
-          org.sonar.api.resources.File sonarFile = new org.sonar.api.resources.File(violation.getFilename());
+          GroovyFile sonarFile = new GroovyFile(violation.getFilename());
           context.saveViolation(Violation.create(rule, sonarFile).setLineId(violation.getLine()).setMessage(violation.getMessage()));
         } else {
           LOG.warn("No such rule in Sonar, so violation from CodeNarc will be ignored: ", violation.getRuleName());

--- a/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensor.java
@@ -94,7 +94,7 @@ public class CodeNarcSensor implements Sensor {
             .withConfigKey(violation.getRuleName());
         Rule rule = ruleFinder.find(ruleQuery);
         if (rule != null) {
-          GroovyFile sonarFile = new GroovyFile(violation.getFilename());
+          GroovyFile sonarFile = GroovyFile.fromRelativePath(violation.getFilename(), violation.getFilename().contains("test/") ? true : false);
           context.saveViolation(Violation.create(rule, sonarFile).setLineId(violation.getLine()).setMessage(violation.getMessage()));
         } else {
           LOG.warn("No such rule in Sonar, so violation from CodeNarc will be ignored: ", violation.getRuleName());

--- a/src/main/java/org/sonar/plugins/groovy/foundation/Groovy.java
+++ b/src/main/java/org/sonar/plugins/groovy/foundation/Groovy.java
@@ -24,6 +24,7 @@ import org.sonar.api.resources.AbstractLanguage;
 
 public class Groovy extends AbstractLanguage {
 
+  public static final Groovy INSTANCE = new Groovy();
   public static final String KEY = "grvy";
 
   public Groovy() {
@@ -33,5 +34,7 @@ public class Groovy extends AbstractLanguage {
   public String[] getFileSuffixes() {
     return new String[] {"groovy"};
   }
+
+
 
 }

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/AbstractAnalyzer.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/AbstractAnalyzer.java
@@ -1,0 +1,302 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import org.apache.commons.lang.StringUtils;
+import org.jacoco.core.analysis.Analyzer;
+import org.jacoco.core.analysis.CoverageBuilder;
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ILine;
+import org.jacoco.core.analysis.ISourceFileCoverage;
+import org.jacoco.core.data.ExecutionData;
+import org.jacoco.core.data.ExecutionDataReader;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.runtime.WildcardMatcher;
+import org.sonar.api.batch.SensorContext;
+import org.sonar.api.component.ResourcePerspectives;
+import org.sonar.api.measures.CoverageMeasuresBuilder;
+import org.sonar.api.measures.Measure;
+import org.sonar.plugins.groovy.jacoco.GroovyFile;
+import org.sonar.api.resources.Project;
+import org.sonar.api.resources.Resource;
+import org.sonar.api.resources.ResourceUtils;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
+import org.sonar.api.scan.filesystem.PathResolver;
+import org.sonar.api.test.MutableTestCase;
+import org.sonar.api.test.MutableTestPlan;
+import org.sonar.api.test.MutableTestable;
+import org.sonar.api.test.Testable;
+import org.sonar.api.utils.SonarException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public abstract class AbstractAnalyzer {
+
+  private final ResourcePerspectives perspectives;
+  private final ModuleFileSystem fileSystem;
+  private final PathResolver pathResolver;
+
+  public AbstractAnalyzer(ResourcePerspectives perspectives, ModuleFileSystem fileSystem, PathResolver pathResolver) {
+    this.perspectives = perspectives;
+    this.fileSystem = fileSystem;
+    this.pathResolver = pathResolver;
+  }
+
+  private static boolean isExcluded(ISourceFileCoverage coverage, WildcardMatcher excludesMatcher) {
+    String name = coverage.getPackageName() + "/" + coverage.getName();
+    return excludesMatcher.matches(name);
+  }
+
+  @VisibleForTesting
+  static GroovyFile getResource(ISourceFileCoverage coverage, SensorContext context) {
+    String packageName = StringUtils.replaceChars(coverage.getPackageName(), '/', '.');
+    String fileName = StringUtils.substringBeforeLast(coverage.getName(), ".");
+
+    GroovyFile resource = new GroovyFile(packageName, fileName);
+    GroovyFile resourceInContext = context.getResource(resource);
+    if (null == resourceInContext) {
+      // no source found?
+      resourceInContext = resource;
+    }
+    if (ResourceUtils.isUnitTestClass(resourceInContext)) {
+      // Ignore unit tests
+      return null;
+    }
+
+    return resourceInContext;
+  }
+
+  public final void analyse(Project project, SensorContext context) {
+    if (!atLeastOneBinaryDirectoryExists()) {
+      JaCoCoUtils.LOG.info("Project coverage is set to 0% since there is no directories with classes.");
+      return;
+    }
+    String path = getReportPath(project);
+    if (path == null) {
+        JaCoCoUtils.LOG.info("No jacoco coverage execution file found for project " + project.getName() + ".");
+        return;
+    }
+    File jacocoExecutionData = pathResolver.relativeFile(fileSystem.baseDir(), path);
+
+    WildcardMatcher excludes = new WildcardMatcher(Strings.nullToEmpty(getExcludes(project)));
+    try {
+      readExecutionData(jacocoExecutionData, context, excludes);
+    } catch (IOException e) {
+      throw new SonarException(e);
+    }
+  }
+
+  private boolean atLeastOneBinaryDirectoryExists() {
+    for (File binaryDir : fileSystem.binaryDirs()) {
+      if (binaryDir.exists()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public final void readExecutionData(File jacocoExecutionData, SensorContext context, WildcardMatcher excludes) throws IOException {
+    ExecutionDataVisitor executionDataVisitor = new ExecutionDataVisitor();
+
+    if (jacocoExecutionData == null || !jacocoExecutionData.exists() || !jacocoExecutionData.isFile()) {
+      JaCoCoUtils.LOG.info("Project coverage is set to 0% as no JaCoCo execution data has been dumped: {}", jacocoExecutionData);
+    } else {
+      JaCoCoUtils.LOG.info("Analysing {}", jacocoExecutionData);
+
+      ExecutionDataReader reader = new ExecutionDataReader(new FileInputStream(jacocoExecutionData));
+      reader.setSessionInfoVisitor(executionDataVisitor);
+      reader.setExecutionDataVisitor(executionDataVisitor);
+      reader.read();
+    }
+
+    boolean collectedCoveragePerTest = false;
+    for (Map.Entry<String, ExecutionDataStore> entry : executionDataVisitor.getSessions().entrySet()) {
+      if (analyzeLinesCoveredByTests(entry.getKey(), entry.getValue(), context, excludes)) {
+        collectedCoveragePerTest = true;
+      }
+    }
+
+    CoverageBuilder coverageBuilder = analyze(executionDataVisitor.getMerged());
+    int analyzedResources = 0;
+    for (ISourceFileCoverage coverage : coverageBuilder.getSourceFiles()) {
+      GroovyFile resource = getResource(coverage, context);
+      if (resource != null) {
+        if (!isExcluded(coverage, excludes)) {
+          CoverageMeasuresBuilder builder = analyzeFile(resource, coverage);
+          saveMeasures(context, resource, builder.createMeasures());
+        }
+        analyzedResources++;
+      }
+    }
+    if (analyzedResources == 0) {
+      JaCoCoUtils.LOG.warn("Coverage information was not collected. Perhaps you forget to include debug information into compiled classes?");
+    } else if (collectedCoveragePerTest) {
+      JaCoCoUtils.LOG.info("Information about coverage per test has been collected.");
+    } else {
+      JaCoCoUtils.LOG.info("No information about coverage per test.");
+    }
+  }
+
+  private boolean analyzeLinesCoveredByTests(String sessionId, ExecutionDataStore executionDataStore, SensorContext context, WildcardMatcher excludes) {
+    int i = sessionId.indexOf(' ');
+    if (i < 0) {
+      return false;
+    }
+    String testClassName = sessionId.substring(0, i);
+    String testName = sessionId.substring(i + 1);
+    Resource testResource = context.getResource(new GroovyFile(testClassName, true));
+    if (testResource == null) {
+      // No such test class
+      return false;
+    }
+
+    boolean result = false;
+    CoverageBuilder coverageBuilder = analyze2(executionDataStore);
+    for (ISourceFileCoverage coverage : coverageBuilder.getSourceFiles()) {
+      GroovyFile resource = getResource(coverage, context);
+      if (resource != null && !isExcluded(coverage, excludes)) {
+        CoverageMeasuresBuilder builder = analyzeFile(resource, coverage);
+        List<Integer> coveredLines = getCoveredLines(builder);
+        if (!coveredLines.isEmpty() && addCoverage(resource, testResource, testName, coveredLines)) {
+          result = true;
+        }
+      }
+    }
+    return result;
+  }
+
+  private CoverageBuilder analyze2(ExecutionDataStore executionDataStore) {
+    CoverageBuilder coverageBuilder = new CoverageBuilder();
+    Analyzer analyzer = new Analyzer(executionDataStore, coverageBuilder);
+    for (File binaryDir : fileSystem.binaryDirs()) {
+      for (ExecutionData data : executionDataStore.getContents()) {
+        String vmClassName = data.getName();
+        String classFileName = vmClassName.replace('.', '/') + ".class";
+        File classFile = new File(binaryDir, classFileName);
+        if (classFile.isFile()) {
+          try {
+            analyzer.analyzeAll(classFile);
+          } catch (Exception e) {
+            JaCoCoUtils.LOG.warn("Exception during analysis of file " + classFile.getAbsolutePath(), e);
+          }
+        }
+      }
+    }
+    return coverageBuilder;
+  }
+
+  private List<Integer> getCoveredLines(CoverageMeasuresBuilder builder) {
+    List<Integer> linesCover = newArrayList();
+    for (Map.Entry<Integer, Integer> hitsByLine : builder.getHitsByLine().entrySet()) {
+      if (hitsByLine.getValue() > 0) {
+        linesCover.add(hitsByLine.getKey());
+      }
+    }
+    return linesCover;
+  }
+
+  private boolean addCoverage(GroovyFile resource, Resource testFile, String testName, List<Integer> coveredLines) {
+    boolean result = false;
+    Testable testAbleFile = perspectives.as(MutableTestable.class, resource);
+    if (testAbleFile != null) {
+      MutableTestPlan testPlan = perspectives.as(MutableTestPlan.class, testFile);
+      if (testPlan != null) {
+        for (MutableTestCase testCase : testPlan.testCasesByName(testName)) {
+          testCase.setCoverageBlock(testAbleFile, coveredLines);
+          result = true;
+        }
+      }
+    }
+    return result;
+  }
+
+  private CoverageBuilder analyze(ExecutionDataStore executionDataStore) {
+    CoverageBuilder coverageBuilder = new CoverageBuilder();
+    Analyzer analyzer = new Analyzer(executionDataStore, coverageBuilder);
+    for (File binaryDir : fileSystem.binaryDirs()) {
+      analyzeAll(analyzer, binaryDir);
+    }
+    return coverageBuilder;
+  }
+
+  /**
+   * Copied from {@link Analyzer#analyzeAll(File)} in order to add logging.
+   */
+  private void analyzeAll(Analyzer analyzer, File file) {
+    if (file.isDirectory()) {
+      for (File f : file.listFiles()) {
+        analyzeAll(analyzer, f);
+      }
+    } else if (file.getName().endsWith(".class")) {
+      try {
+        analyzer.analyzeAll(file);
+      } catch (Exception e) {
+        JaCoCoUtils.LOG.warn("Exception during analysis of file " + file.getAbsolutePath(), e);
+      }
+    }
+  }
+
+  private CoverageMeasuresBuilder analyzeFile(GroovyFile resource, ISourceFileCoverage coverage) {
+    CoverageMeasuresBuilder builder = CoverageMeasuresBuilder.create();
+    for (int lineId = coverage.getFirstLine(); lineId <= coverage.getLastLine(); lineId++) {
+      final int hits;
+      ILine line = coverage.getLine(lineId);
+      switch (line.getInstructionCounter().getStatus()) {
+        case ICounter.FULLY_COVERED:
+        case ICounter.PARTLY_COVERED:
+          hits = 1;
+          break;
+        case ICounter.NOT_COVERED:
+          hits = 0;
+          break;
+        case ICounter.EMPTY:
+          continue;
+        default:
+          JaCoCoUtils.LOG.warn("Unknown status for line {} in {}", lineId, resource);
+          continue;
+      }
+      builder.setHits(lineId, hits);
+
+      ICounter branchCounter = line.getBranchCounter();
+      int conditions = branchCounter.getTotalCount();
+      if (conditions > 0) {
+        int coveredConditions = branchCounter.getCoveredCount();
+        builder.setConditions(lineId, conditions, coveredConditions);
+      }
+    }
+    return builder;
+  }
+
+  protected abstract void saveMeasures(SensorContext context, GroovyFile resource, Collection<Measure> measures);
+
+  protected abstract String getReportPath(Project project);
+
+  protected abstract String getExcludes(Project project);
+
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/ExecutionDataVisitor.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/ExecutionDataVisitor.java
@@ -1,0 +1,67 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import com.google.common.collect.Maps;
+import org.jacoco.core.data.ExecutionData;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.data.IExecutionDataVisitor;
+import org.jacoco.core.data.ISessionInfoVisitor;
+import org.jacoco.core.data.SessionInfo;
+
+import java.util.Map;
+
+public class ExecutionDataVisitor implements ISessionInfoVisitor, IExecutionDataVisitor {
+
+  private final Map<String, ExecutionDataStore> sessions = Maps.newHashMap();
+
+  private ExecutionDataStore executionDataStore;
+  private ExecutionDataStore merged = new ExecutionDataStore();
+
+  public void visitSessionInfo(SessionInfo info) {
+    String sessionId = info.getId();
+    executionDataStore = sessions.get(sessionId);
+    if (executionDataStore == null) {
+      executionDataStore = new ExecutionDataStore();
+      sessions.put(sessionId, executionDataStore);
+    }
+  }
+
+  public void visitClassExecution(ExecutionData data) {
+    executionDataStore.put(data);
+    merged.put(defensiveCopy(data));
+  }
+
+  public Map<String, ExecutionDataStore> getSessions() {
+    return sessions;
+  }
+
+  public ExecutionDataStore getMerged() {
+    return merged;
+  }
+
+  private static ExecutionData defensiveCopy(ExecutionData data) {
+    boolean[] src = data.getProbes();
+    boolean[] dest = new boolean[src.length];
+    System.arraycopy(src, 0, dest, 0, src.length);
+    return new ExecutionData(data.getId(), data.getName(), dest);
+  }
+
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/GroovyFile.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/GroovyFile.java
@@ -19,7 +19,6 @@
  */
 package  org.sonar.plugins.groovy.jacoco;
 
-import org.sonar.api.resources.JavaPackage;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.resources.Resource;
 import org.sonar.api.resources.Language;
@@ -37,13 +36,13 @@ import java.util.List;
  * A class that represents a Groovy class. This class can either be a Test class or source class
  *
  */
-public class GroovyFile extends Resource<JavaPackage> {
+public class GroovyFile extends Resource<GroovyPackage> {
 
   private String filename;
   private String longName;
   private String packageKey;
   private boolean unitTest;
-  private JavaPackage parent;
+  private GroovyPackage parent;
 
   /**
    * Creates a GroovyFile that is not a class of test based on package and file names
@@ -59,63 +58,63 @@ public class GroovyFile extends Resource<JavaPackage> {
    */
   public GroovyFile(String packageKey, String className, boolean unitTest) {
     if (className == null) {
-      throw new IllegalArgumentException("Groovy filename can not be null");
+        throw new IllegalArgumentException("Groovy filename can not be null");
     }
-    this.filename = StringUtils.trim(className) + ".groovy";
+    this.filename = StringUtils.trim(className);
     String key;
     if (StringUtils.isBlank(packageKey)) {
-      this.packageKey = JavaPackage.DEFAULT_PACKAGE_NAME;
-      this.longName = this.filename;
-      key = new StringBuilder().append(this.packageKey).append(".").append(this.filename).toString();
+        this.packageKey = GroovyPackage.DEFAULT_PACKAGE_NAME;
+        this.longName = this.filename;
+        key = new StringBuilder().append(this.packageKey).append(".").append(this.filename).toString();
     } else {
-      this.packageKey = packageKey.trim();
-      key = new StringBuilder().append(this.packageKey).append(".").append(this.filename).toString();
-      this.longName = key;
+        this.packageKey = packageKey.trim();
+        key = new StringBuilder().append(this.packageKey).append(".").append(this.filename).toString();
+        this.longName = key;
     }
     setKey(key);
     this.unitTest = unitTest;
   }
 
-  /**
-   * Creates a source file from its key
-   */
-  public GroovyFile(String key) {
-    this(key, false);
-  }
-
-  /**
-   * Creates any GroovyFile from its key
-   *
-   * @param unitTest whether it is a unit test file or a source file
-   */
-  public GroovyFile(String key, boolean unitTest) {
-    if (key == null) {
-      throw new IllegalArgumentException("Groovy filename can not be null");
+    /**
+     * Creates a source file from its key
+     */
+    public GroovyFile(String key) {
+        this(key, false);
     }
-    String realKey = StringUtils.trim(key);
-    this.unitTest = unitTest;
 
-    if (realKey.contains(".")) {
-      this.filename = StringUtils.substringAfterLast(realKey, ".");
-      this.packageKey = StringUtils.substringBeforeLast(realKey, ".");
-      this.longName = realKey;
+    /**
+     * Creates any GroovyFile from its key
+     *
+     * @param unitTest whether it is a unit test file or a source file
+     */
+    public GroovyFile(String key, boolean unitTest) {
+        if (key == null) {
+            throw new IllegalArgumentException("Groovy filename can not be null");
+        }
+        String realKey = StringUtils.trim(key);
+        this.unitTest = unitTest;
 
-    } else {
-      this.filename = realKey;
-      this.longName = realKey;
-      this.packageKey = JavaPackage.DEFAULT_PACKAGE_NAME;
-      realKey = new StringBuilder().append(JavaPackage.DEFAULT_PACKAGE_NAME).append(".").append(realKey).append(".groovy").toString();
+        if (realKey.contains(".")) {
+            this.filename = StringUtils.substringAfterLast(realKey, ".");
+            this.packageKey = StringUtils.substringBeforeLast(realKey, ".");
+            this.longName = realKey;
+
+        } else {
+            this.filename = realKey;
+            this.longName = realKey;
+            this.packageKey = GroovyPackage.DEFAULT_PACKAGE_NAME;
+            realKey = new StringBuilder().append(GroovyPackage.DEFAULT_PACKAGE_NAME).append(".").append(realKey).toString();
+        }
+        setKey(realKey);
     }
-    setKey(realKey);
-  }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public JavaPackage getParent() {
+  public GroovyPackage getParent() {
     if (parent == null) {
-      parent = new JavaPackage(packageKey);
+      parent = new GroovyPackage(packageKey);
     }
     return parent;
 
@@ -130,7 +129,7 @@ public class GroovyFile extends Resource<JavaPackage> {
   }
 
   /**
-   * @return Java
+   * @return Groovy
    */
   @Override
   public Language getLanguage() {

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/GroovyFile.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/GroovyFile.java
@@ -1,0 +1,242 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package  org.sonar.plugins.groovy.jacoco;
+
+import org.sonar.api.resources.JavaPackage;
+import org.sonar.api.resources.Qualifiers;
+import org.sonar.api.resources.Resource;
+import org.sonar.api.resources.Language;
+
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.resources.Scopes;
+import org.sonar.api.scan.filesystem.PathResolver;
+import org.sonar.api.utils.WildcardPattern;
+import org.sonar.plugins.groovy.foundation.Groovy;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * A class that represents a Groovy class. This class can either be a Test class or source class
+ *
+ */
+public class GroovyFile extends Resource<JavaPackage> {
+
+  private String filename;
+  private String longName;
+  private String packageKey;
+  private boolean unitTest;
+  private JavaPackage parent;
+
+  /**
+   * Creates a GroovyFile that is not a class of test based on package and file names
+   */
+  public GroovyFile(String packageName, String className) {
+    this(packageName, className, false);
+  }
+
+  /**
+   * Creates a GroovyFile that can be of any type based on package and file names
+   *
+   * @param unitTest whether it is a unit test file or a source file
+   */
+  public GroovyFile(String packageKey, String className, boolean unitTest) {
+    if (className == null) {
+      throw new IllegalArgumentException("Groovy filename can not be null");
+    }
+    this.filename = StringUtils.trim(className) + ".groovy";
+    String key;
+    if (StringUtils.isBlank(packageKey)) {
+      this.packageKey = JavaPackage.DEFAULT_PACKAGE_NAME;
+      this.longName = this.filename;
+      key = new StringBuilder().append(this.packageKey).append(".").append(this.filename).toString();
+    } else {
+      this.packageKey = packageKey.trim();
+      key = new StringBuilder().append(this.packageKey).append(".").append(this.filename).toString();
+      this.longName = key;
+    }
+    setKey(key);
+    this.unitTest = unitTest;
+  }
+
+  /**
+   * Creates a source file from its key
+   */
+  public GroovyFile(String key) {
+    this(key, false);
+  }
+
+  /**
+   * Creates any GroovyFile from its key
+   *
+   * @param unitTest whether it is a unit test file or a source file
+   */
+  public GroovyFile(String key, boolean unitTest) {
+    if (key == null) {
+      throw new IllegalArgumentException("Groovy filename can not be null");
+    }
+    String realKey = StringUtils.trim(key);
+    this.unitTest = unitTest;
+
+    if (realKey.contains(".")) {
+      this.filename = StringUtils.substringAfterLast(realKey, ".");
+      this.packageKey = StringUtils.substringBeforeLast(realKey, ".");
+      this.longName = realKey;
+
+    } else {
+      this.filename = realKey;
+      this.longName = realKey;
+      this.packageKey = JavaPackage.DEFAULT_PACKAGE_NAME;
+      realKey = new StringBuilder().append(JavaPackage.DEFAULT_PACKAGE_NAME).append(".").append(realKey).append(".groovy").toString();
+    }
+    setKey(realKey);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public JavaPackage getParent() {
+    if (parent == null) {
+      parent = new JavaPackage(packageKey);
+    }
+    return parent;
+
+  }
+
+  /**
+   * @return null
+   */
+  @Override
+  public String getDescription() {
+    return null;
+  }
+
+  /**
+   * @return Java
+   */
+  @Override
+  public Language getLanguage() {
+    return Groovy.INSTANCE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getName() {
+    return filename;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getLongName() {
+    return longName;
+  }
+
+  /**
+   * @return SCOPE_ENTITY
+   */
+  @Override
+  public String getScope() {
+    return Scopes.FILE;
+  }
+
+  /**
+   * @return QUALIFIER_UNIT_TEST_CLASS or QUALIFIER_CLASS depending whether it is a unit test class
+   */
+  @Override
+  public String getQualifier() {
+    return unitTest ? Qualifiers.UNIT_TEST_FILE : Qualifiers.CLASS;
+  }
+
+  /**
+   * @return whether the GroovyFile is a unit test class or not
+   */
+  public boolean isUnitTest() {
+    return unitTest;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean matchFilePattern(String antPattern) {
+    String fileKey = getKey();
+    if (!fileKey.endsWith(".groovy")) {
+      fileKey += ".groovy";
+    }
+    if (StringUtils.substringAfterLast(antPattern, "/").indexOf(".") < 0) {
+      antPattern += ".*";
+    }
+    WildcardPattern matcher = WildcardPattern.create(antPattern, ".");
+    return matcher.match(fileKey);
+  }
+
+  public static GroovyFile fromRelativePath(String relativePath, boolean unitTest) {
+    if (relativePath != null) {
+      String pacname = null;
+      String classname = relativePath;
+
+      if (relativePath.indexOf('/') >= 0) {
+        pacname = StringUtils.substringBeforeLast(relativePath, "/");
+        pacname = StringUtils.replace(pacname, "/", ".");
+        classname = StringUtils.substringAfterLast(relativePath, "/");
+      }
+      classname = StringUtils.substringBeforeLast(classname, ".");
+      return new GroovyFile(pacname, classname, unitTest);
+    }
+    return null;
+  }
+
+  /**
+   *  Creates a GroovyFile from a file in the source directories
+   *
+   * @return the GroovyFile created if exists, null otherwise
+   */
+  public static GroovyFile fromIOFile(File file, List<File> sourceDirs, boolean unitTest) {
+    if (file == null || !StringUtils.endsWithIgnoreCase(file.getName(), ".groovy")) {
+      return null;
+    }
+    PathResolver.RelativePath relativePath = new PathResolver().relativePath(sourceDirs, file);
+    if (relativePath != null) {
+      return fromRelativePath(relativePath.path(), unitTest);
+    }
+    return null;
+  }
+
+  /**
+   * Shortcut to fromIOFile with an abolute path
+   */
+  public static GroovyFile fromAbsolutePath(String path, List<File> sourceDirs, boolean unitTest) {
+    if (path == null) {
+      return null;
+    }
+    return fromIOFile(new File(path), sourceDirs, unitTest);
+  }
+
+  @Override
+  public String toString() {
+    return getKey();
+  }
+
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/GroovyPackage.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/GroovyPackage.java
@@ -1,0 +1,40 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package  org.sonar.plugins.groovy.jacoco;
+
+import org.sonar.api.resources.JavaPackage;
+import org.sonar.api.resources.Language;
+import org.sonar.plugins.groovy.foundation.Groovy;
+
+public class GroovyPackage extends JavaPackage {
+
+    public GroovyPackage() {
+        this(null);
+    }
+
+    public GroovyPackage(String key) {
+        super(key);
+    }
+
+    @Override
+    public Language getLanguage() {
+        return Groovy.INSTANCE;
+    }
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoAgentDownloader.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoAgentDownloader.java
@@ -1,0 +1,60 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import org.apache.commons.io.FileUtils;
+import org.jacoco.agent.AgentJar;
+import org.jacoco.core.JaCoCo;
+import org.sonar.api.BatchExtension;
+import org.sonar.api.utils.SonarException;
+
+import java.io.File;
+import java.io.IOException;
+
+public class JaCoCoAgentDownloader implements BatchExtension {
+
+  /**
+   * Dirty hack, but it allows to extract agent only once during Sonar analyzes for multi-module project.
+   */
+  private static File agentJarFile;
+
+  public JaCoCoAgentDownloader() {
+  }
+
+  public synchronized File getAgentJarFile() {
+    if (agentJarFile == null) {
+      agentJarFile = extractAgent();
+    }
+    return agentJarFile;
+  }
+
+  private File extractAgent() {
+    try {
+      File agent = File.createTempFile("jacocoagent", ".jar");
+      AgentJar.extractTo(agent);
+      // TODO evil method
+      FileUtils.forceDeleteOnExit(agent);
+      JaCoCoUtils.LOG.info("JaCoCo agent (version " + JaCoCo.VERSION + ") extracted: {}", agent);
+      return agent;
+    } catch (IOException e) {
+      throw new SonarException(e);
+    }
+  }
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoItSensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoItSensor.java
@@ -1,0 +1,111 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.batch.Sensor;
+import org.sonar.api.batch.SensorContext;
+import org.sonar.api.component.ResourcePerspectives;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.Measure;
+import org.sonar.api.resources.Project;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
+import org.sonar.api.scan.filesystem.PathResolver;
+
+import java.util.Collection;
+
+public class JaCoCoItSensor implements Sensor {
+  private final JacocoConfiguration configuration;
+  private final ResourcePerspectives perspectives;
+  private final ModuleFileSystem fileSystem;
+  private final PathResolver pathResolver;
+
+  public JaCoCoItSensor(JacocoConfiguration configuration, ResourcePerspectives perspectives, ModuleFileSystem fileSystem, PathResolver pathResolver) {
+    this.configuration = configuration;
+    this.perspectives = perspectives;
+    this.fileSystem = fileSystem;
+    this.pathResolver = pathResolver;
+  }
+
+  public boolean shouldExecuteOnProject(Project project) {
+    return configuration.isEnabled(project) && StringUtils.isNotBlank(configuration.getItReportPath());
+  }
+
+  public void analyse(Project project, SensorContext context) {
+    new ITAnalyzer(perspectives).analyse(project, context);
+  }
+
+  class ITAnalyzer extends AbstractAnalyzer {
+    public ITAnalyzer(ResourcePerspectives perspectives) {
+      super(perspectives, fileSystem, pathResolver);
+    }
+
+    @Override
+    protected String getReportPath(Project project) {
+      return configuration.getItReportPath();
+    }
+
+    @Override
+    protected String getExcludes(Project project) {
+      return configuration.getExcludes();
+    }
+
+    @Override
+    protected void saveMeasures(SensorContext context, GroovyFile resource, Collection<Measure> measures) {
+      for (Measure measure : measures) {
+        Measure itMeasure = convertForIT(measure);
+        if (itMeasure != null) {
+          context.saveMeasure(resource, itMeasure);
+        }
+      }
+    }
+
+    private Measure convertForIT(Measure measure) {
+      Measure itMeasure = null;
+      if (CoreMetrics.LINES_TO_COVER.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.IT_LINES_TO_COVER, measure.getValue());
+
+      } else if (CoreMetrics.UNCOVERED_LINES.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.IT_UNCOVERED_LINES, measure.getValue());
+
+      } else if (CoreMetrics.COVERAGE_LINE_HITS_DATA.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.IT_COVERAGE_LINE_HITS_DATA, measure.getData());
+
+      } else if (CoreMetrics.CONDITIONS_TO_COVER.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.IT_CONDITIONS_TO_COVER, measure.getValue());
+
+      } else if (CoreMetrics.UNCOVERED_CONDITIONS.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.IT_UNCOVERED_CONDITIONS, measure.getValue());
+
+      } else if (CoreMetrics.COVERED_CONDITIONS_BY_LINE.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.IT_COVERED_CONDITIONS_BY_LINE, measure.getData());
+
+      } else if (CoreMetrics.CONDITIONS_BY_LINE.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.IT_CONDITIONS_BY_LINE, measure.getData());
+      }
+      return itMeasure;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoMavenPluginHandler.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoMavenPluginHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.batch.maven.MavenPlugin;
+import org.sonar.api.batch.maven.MavenPluginHandler;
+import org.sonar.api.batch.maven.MavenSurefireUtils;
+import org.sonar.api.resources.Project;
+import org.sonar.api.utils.SonarException;
+
+import java.io.File;
+
+public class JaCoCoMavenPluginHandler implements MavenPluginHandler {
+
+  private static final String ARG_LINE_PARAMETER = "argLine";
+  private static final String TEST_FAILURE_IGNORE_PARAMETER = "testFailureIgnore";
+
+  private final String groupId;
+  private final String artifactId;
+  private final String version;
+
+  private JacocoConfiguration configuration;
+
+  public JaCoCoMavenPluginHandler(JacocoConfiguration configuration) {
+    this.configuration = configuration;
+    groupId = MavenSurefireUtils.GROUP_ID;
+    artifactId = MavenSurefireUtils.ARTIFACT_ID;
+    version = MavenSurefireUtils.VERSION;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public String getArtifactId() {
+    return artifactId;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public boolean isFixedVersion() {
+    return false;
+  }
+
+  public String[] getGoals() {
+    return new String[] { "test" };
+  }
+
+  public void configure(Project project, MavenPlugin plugin) {
+    // See SONARPLUGINS-600
+    String destfilePath = configuration.getReportPath();
+    File destfile = project.getFileSystem().resolvePath(destfilePath);
+    if (destfile.exists() && destfile.isFile()) {
+      JaCoCoUtils.LOG.info("Deleting {}", destfile);
+      if (!destfile.delete()) {
+        throw new SonarException("Unable to delete " + destfile);
+      }
+    }
+
+    String argument = configuration.getJvmArgument();
+
+    String argLine = plugin.getParameter(ARG_LINE_PARAMETER);
+    argLine = StringUtils.isBlank(argLine) ? argument : argument + " " + argLine;
+    JaCoCoUtils.LOG.info("JVM options: {}", argLine);
+    plugin.setParameter(ARG_LINE_PARAMETER, argLine);
+
+    plugin.setParameter(TEST_FAILURE_IGNORE_PARAMETER, "true");
+  }
+
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoOverallSensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoOverallSensor.java
@@ -1,0 +1,172 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import com.google.common.io.Closeables;
+import org.apache.commons.lang.StringUtils;
+import org.jacoco.core.data.ExecutionDataReader;
+import org.jacoco.core.data.ExecutionDataStore;
+import org.jacoco.core.data.ExecutionDataWriter;
+import org.jacoco.core.data.SessionInfoStore;
+import org.sonar.api.batch.Sensor;
+import org.sonar.api.batch.SensorContext;
+import org.sonar.api.component.ResourcePerspectives;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.Measure;
+import org.sonar.api.resources.Project;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
+import org.sonar.api.scan.filesystem.PathResolver;
+import org.sonar.api.utils.SonarException;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+public class JaCoCoOverallSensor implements Sensor {
+
+  public static final String JACOCO_OVERALL = "jacoco-overall.exec";
+
+  private final JacocoConfiguration configuration;
+  private final ResourcePerspectives perspectives;
+  private final ModuleFileSystem fileSystem;
+  private final PathResolver pathResolver;
+
+  public JaCoCoOverallSensor(JacocoConfiguration configuration, ResourcePerspectives perspectives, ModuleFileSystem fileSystem, PathResolver pathResolver) {
+    this.configuration = configuration;
+    this.perspectives = perspectives;
+    this.fileSystem = fileSystem;
+    this.pathResolver = pathResolver;
+  }
+
+  public boolean shouldExecuteOnProject(Project project) {
+    return configuration.isEnabled(project) && StringUtils.isNotBlank(configuration.getItReportPath());
+  }
+
+  public void analyse(Project project, SensorContext context) {
+    File reportUTs = pathResolver.relativeFile(fileSystem.baseDir(), configuration.getReportPath());
+    File reportITs = pathResolver.relativeFile(fileSystem.baseDir(), configuration.getItReportPath());
+    if ((!reportUTs.exists()) || (!reportITs.exists())) {
+      return;
+    }
+
+    File reportOverall = new File(fileSystem.workingDir(), JACOCO_OVERALL);
+    reportOverall.getParentFile().mkdirs();
+
+    mergeReports(reportOverall, reportUTs, reportITs);
+
+    new OverallAnalyzer(reportOverall, perspectives).analyse(project, context);
+  }
+
+  private void mergeReports(File reportOverall, File... reports) {
+    SessionInfoStore infoStore = new SessionInfoStore();
+    ExecutionDataStore dataStore = new ExecutionDataStore();
+
+    loadSourceFiles(infoStore, dataStore, reports);
+
+    BufferedOutputStream outputStream = null;
+    try {
+      outputStream = new BufferedOutputStream(new FileOutputStream(reportOverall));
+      ExecutionDataWriter dataWriter = new ExecutionDataWriter(outputStream);
+
+      infoStore.accept(dataWriter);
+      dataStore.accept(dataWriter);
+    } catch (IOException e) {
+      throw new SonarException(String.format("Unable to write overall coverage report %s", reportOverall.getAbsolutePath()), e);
+    } finally {
+      Closeables.closeQuietly(outputStream);
+    }
+  }
+
+  private void loadSourceFiles(SessionInfoStore infoStore, ExecutionDataStore dataStore, File... reports) {
+    for (File report : reports) {
+      InputStream resourceStream = null;
+      try {
+        resourceStream = new BufferedInputStream(new FileInputStream(report));
+        ExecutionDataReader reader = new ExecutionDataReader(resourceStream);
+        reader.setSessionInfoVisitor(infoStore);
+        reader.setExecutionDataVisitor(dataStore);
+        reader.read();
+      } catch (IOException e) {
+        throw new SonarException(String.format("Unable to read %s", report.getAbsolutePath()), e);
+      } finally {
+        Closeables.closeQuietly(resourceStream);
+      }
+    }
+  }
+
+  class OverallAnalyzer extends AbstractAnalyzer {
+    private final File report;
+
+    OverallAnalyzer(File report, ResourcePerspectives perspectives) {
+      super(perspectives, fileSystem, pathResolver);
+      this.report = report;
+    }
+
+    @Override
+    protected String getReportPath(Project project) {
+      return report.getAbsolutePath();
+    }
+
+    @Override
+    protected String getExcludes(Project project) {
+      return configuration.getExcludes();
+    }
+
+    @Override
+    protected void saveMeasures(SensorContext context, GroovyFile resource, Collection<Measure> measures) {
+      for (Measure measure : measures) {
+        Measure mergedMeasure = convertForOverall(measure);
+        if (mergedMeasure != null) {
+          context.saveMeasure(resource, mergedMeasure);
+        }
+      }
+    }
+
+    private Measure convertForOverall(Measure measure) {
+      Measure itMeasure = null;
+      if (CoreMetrics.LINES_TO_COVER.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.OVERALL_LINES_TO_COVER, measure.getValue());
+      } else if (CoreMetrics.UNCOVERED_LINES.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.OVERALL_UNCOVERED_LINES, measure.getValue());
+      } else if (CoreMetrics.COVERAGE_LINE_HITS_DATA.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.OVERALL_COVERAGE_LINE_HITS_DATA, measure.getData());
+      } else if (CoreMetrics.CONDITIONS_TO_COVER.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.OVERALL_CONDITIONS_TO_COVER, measure.getValue());
+      } else if (CoreMetrics.UNCOVERED_CONDITIONS.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.OVERALL_UNCOVERED_CONDITIONS, measure.getValue());
+      } else if (CoreMetrics.COVERED_CONDITIONS_BY_LINE.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.OVERALL_COVERED_CONDITIONS_BY_LINE, measure.getData());
+      } else if (CoreMetrics.CONDITIONS_BY_LINE.equals(measure.getMetric())) {
+        itMeasure = new Measure(CoreMetrics.OVERALL_CONDITIONS_BY_LINE, measure.getData());
+      }
+      return itMeasure;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoSensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoSensor.java
@@ -1,0 +1,91 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import org.sonar.api.batch.DependsUpon;
+import org.sonar.api.batch.Sensor;
+import org.sonar.api.batch.SensorContext;
+import org.sonar.api.component.ResourcePerspectives;
+import org.sonar.api.measures.Measure;
+import org.sonar.api.resources.Project;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
+import org.sonar.api.scan.filesystem.PathResolver;
+
+import java.util.Collection;
+
+public class JaCoCoSensor implements Sensor {
+
+  private JacocoConfiguration configuration;
+  private final ResourcePerspectives perspectives;
+  private final ModuleFileSystem fileSystem;
+  private final PathResolver pathResolver;
+
+  public JaCoCoSensor(JacocoConfiguration configuration, ResourcePerspectives perspectives, ModuleFileSystem fileSystem, PathResolver pathResolver) {
+    this.configuration = configuration;
+    this.perspectives = perspectives;
+    this.fileSystem = fileSystem;
+    this.pathResolver = pathResolver;
+  }
+
+  @DependsUpon
+  public String dependsUponSurefireSensors() {
+    return "surefire-groovy";
+  }
+
+  public void analyse(Project project, SensorContext context) {
+    new UnitTestsAnalyzer(perspectives).analyse(project, context);
+  }
+
+  public boolean shouldExecuteOnProject(Project project) {
+    if(!configuration.isEnabled(project)) {
+      JaCoCoUtils.LOG.warn("Jacoco is not enabled for project " + project.getName());
+    }
+    return configuration.isEnabled(project);
+  }
+
+  class UnitTestsAnalyzer extends AbstractAnalyzer {
+    public UnitTestsAnalyzer(ResourcePerspectives perspectives) {
+      super(perspectives, fileSystem, pathResolver);
+    }
+
+    @Override
+    protected String getReportPath(Project project) {
+      return configuration.getReportPath();
+    }
+
+    @Override
+    protected String getExcludes(Project project) {
+      return configuration.getExcludes();
+    }
+
+    @Override
+    protected void saveMeasures(SensorContext context, GroovyFile resource, Collection<Measure> measures) {
+      for (Measure measure : measures) {
+        context.saveMeasure(resource, measure);
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoUtils.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JaCoCoUtils.java
@@ -17,36 +17,20 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
+package org.sonar.plugins.groovy.jacoco;
 
-package org.sonar.plugins.groovy.foundation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import net.sourceforge.pmd.cpd.Tokenizer;
-import org.sonar.api.batch.AbstractCpdMapping;
-import org.sonar.api.resources.Language;
-import org.sonar.api.resources.Resource;
-import org.sonar.plugins.groovy.jacoco.GroovyFile;
+public final class JaCoCoUtils {
 
-import java.io.File;
-import java.util.List;
-
-public class GroovyCpdMapping extends AbstractCpdMapping {
-
-  private final Groovy language;
-
-  public GroovyCpdMapping(Groovy language) {
-    this.language = language;
+  /**
+   * Utility class constructor.
+   */
+  private JaCoCoUtils() {
   }
 
-  public Resource createResource(java.io.File file, List<File> sourceDirs) {
-    return GroovyFile.fromIOFile(file, sourceDirs, false);
-  }
-
-  public Tokenizer getTokenizer() {
-    return new GroovyCpdTokenizer();
-  }
-
-  public Language getLanguage() {
-    return language;
-  }
+  public static final String PLUGIN_KEY = "jacoco";
+  public static final Logger LOG = LoggerFactory.getLogger(JaCoCoUtils.class.getName());
 
 }

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JacocoAntInitializer.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JacocoAntInitializer.java
@@ -1,0 +1,151 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import org.apache.tools.ant.*;
+import org.sonar.api.batch.CoverageExtension;
+import org.sonar.api.batch.Initializer;
+import org.sonar.api.batch.SupportedEnvironment;
+import org.sonar.api.resources.Project;
+
+import java.util.Map;
+
+@SupportedEnvironment("ant")
+public class JacocoAntInitializer extends Initializer implements CoverageExtension {
+
+  private final TaskEnhancer[] taskEnhancers = new TaskEnhancer[] {
+          new GroovyLikeTaskEnhancer("groovyc"),
+          new GroovyLikeTaskEnhancer("groovy"),
+          new GroovyLikeTaskEnhancer("gradle"),
+          new GroovyLikeTaskEnhancer("grails"),
+          new GroovyLikeTaskEnhancer("junit"),
+          new GroovyLikeTaskEnhancer("test"),
+          new GroovyLikeTaskEnhancer("java"),
+          new TestngTaskEnhancer() };
+
+  private org.apache.tools.ant.Project antProject;
+  private JacocoConfiguration configuration;
+
+  public JacocoAntInitializer(org.apache.tools.ant.Project antProject, JacocoConfiguration configuration) {
+    this.antProject = antProject;
+    this.configuration = configuration;
+  }
+
+  @Override
+  public boolean shouldExecuteOnProject(org.sonar.api.resources.Project project) {
+    return configuration.isEnabled(project) && project.getAnalysisType().equals(Project.AnalysisType.DYNAMIC);
+  }
+
+  @Override
+  public void execute(org.sonar.api.resources.Project project) {
+    Map<String, Target> hastable = antProject.getTargets();
+    String jvmArg = configuration.getJvmArgument();
+    String[] names = configuration.getAntTargets();
+    for (String name : names) {
+      Target target = hastable.get(name);
+      if (target == null) {
+        JaCoCoUtils.LOG.warn("Target '{}' not found", name);
+      } else {
+        // Enhance target
+        for (Task task : target.getTasks()) {
+          for (TaskEnhancer enhancer : taskEnhancers) {
+            if (enhancer.supportsTask(task)) {
+              enhancer.enhanceTask(task, jvmArg);
+            }
+          }
+        }
+        // Execute target
+        target.performTasks();
+      }
+    }
+  }
+
+  private static class TestngTaskEnhancer extends TaskEnhancer {
+    @Override
+    public boolean supportsTask(Task task) {
+      return "testng".equals(task.getTaskName());
+    }
+  }
+
+  /**
+   * Basic task enhancer that can handle all 'java like' tasks. That is, tasks
+   * that have a top level fork attribute and nested jvmargs elements
+   */
+  private static class GroovyLikeTaskEnhancer extends TaskEnhancer {
+    private String taskName;
+
+    public GroovyLikeTaskEnhancer(String taskName) {
+      this.taskName = taskName;
+    }
+
+    @Override
+    public boolean supportsTask(final Task task) {
+      return taskName.equals(task.getTaskName());
+    }
+
+    @Override
+    public void enhanceTask(final Task task, final String jvmArg) {
+      final RuntimeConfigurable configurableWrapper = task.getRuntimeConfigurableWrapper();
+
+      final String forkValue = (String) configurableWrapper.getAttributeMap().get("fork");
+
+      if (forkValue == null || !org.apache.tools.ant.Project.toBoolean(forkValue)) {
+        throw new BuildException("Coverage can only be applied on a forked VM");
+      }
+
+      super.enhanceTask(task, jvmArg);
+    }
+
+  }
+
+  private abstract static class TaskEnhancer {
+    /**
+     * @param task Task instance to enhance
+     * @return <code>true</code> if this enhancer is capable of enhancing the requested task
+     */
+    public abstract boolean supportsTask(Task task);
+
+    /**
+     * Attempt to enhance the supplied task with coverage information. This
+     * operation may fail if the task is being executed in the current VM
+     *
+     * @param task Task instance to enhance (usually an {@link UnknownElement})
+     * @param jvmArg
+     * @throws BuildException Thrown if this enhancer can handle this type of task, but this instance can not be enhanced for some reason.
+     */
+    public void enhanceTask(Task task, String jvmArg) {
+      addJvmArg((UnknownElement) task, jvmArg);
+    }
+
+    public void addJvmArg(final UnknownElement task, final String jvmArg) {
+      final UnknownElement el = new UnknownElement("jvmarg");
+      el.setTaskName("jvmarg");
+      el.setQName("jvmarg");
+
+      final RuntimeConfigurable runtimeConfigurableWrapper = el.getRuntimeConfigurableWrapper();
+      runtimeConfigurableWrapper.setAttribute("value", jvmArg);
+
+      task.getRuntimeConfigurableWrapper().addChild(runtimeConfigurableWrapper);
+
+      task.addChild(el);
+    }
+  }
+
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JacocoConfiguration.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JacocoConfiguration.java
@@ -1,0 +1,171 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import org.sonar.api.Properties;
+import org.sonar.api.Property;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.StringUtils;
+import org.jacoco.core.runtime.AgentOptions;
+import org.sonar.api.BatchExtension;
+import org.sonar.api.CoreProperties;
+import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.config.Settings;
+import org.sonar.api.resources.Java;
+import org.sonar.api.resources.Project;
+import org.sonar.api.resources.Qualifiers;
+import org.sonar.plugins.groovy.foundation.Groovy;
+import org.sonar.plugins.java.api.JavaSettings;
+
+import java.util.List;
+
+@Properties({
+  @Property(
+    key = JacocoConfiguration.REPORT_PATH_PROPERTY,
+    defaultValue = JacocoConfiguration.REPORT_PATH_DEFAULT_VALUE,
+    category = CoreProperties.CATEGORY_JAVA,
+    name = "File with execution data",
+    description = "Path (absolute or relative) to the file with execution data.",
+    module = true,
+    project = true,
+    global = false),
+  @Property(
+    key = JacocoConfiguration.INCLUDES_PROPERTY,
+    multiValues = true,
+    category = CoreProperties.CATEGORY_JAVA,
+    name = "Includes",
+    description = "A list of class names that should be included in execution analysis (see wildcards)." +
+      " Except for performance optimization or technical corner cases this option is normally not required.",
+    module = true,
+    project = true,
+    global = false),
+  @Property(
+    key = JacocoConfiguration.EXCLUDES_PROPERTY,
+    defaultValue = JacocoConfiguration.EXCLUDES_DEFAULT_VALUE,
+    multiValues = true,
+    category = CoreProperties.CATEGORY_JAVA,
+    name = "Excludes",
+    description = "A list of class names that should be excluded from execution analysis (see wildcards)." +
+      " Except for performance optimization or technical corner cases this option is normally not required.",
+    module = true,
+    project = true,
+    global = false),
+  @Property(
+    key = JacocoConfiguration.EXCLCLASSLOADER_PROPERTY,
+    multiValues = true,
+    category = CoreProperties.CATEGORY_JAVA,
+    name = "Excluded class loaders",
+    description = "A list of class loader names that should be excluded from execution analysis (see wildcards)." +
+      " This option might be required in case of special frameworks that conflict with JaCoCo code" +
+      " instrumentation, in particular class loaders that do not have access to the Java runtime classes.",
+    module = true,
+    project = true,
+    global = false),
+  @Property(
+    key = JacocoConfiguration.IT_REPORT_PATH_PROPERTY,
+    defaultValue = JacocoConfiguration.IT_REPORT_PATH_DEFAULT_VALUE,
+    category = CoreProperties.CATEGORY_JAVA,
+    name = "File with execution data for integration tests",
+    description = "Path (absolute or relative) to the file with execution data.",
+    module = true,
+    project = true,
+    global = false),
+  @Property(
+     key = JacocoConfiguration.ANT_TARGETS_PROPERTY,
+    defaultValue = JacocoConfiguration.ANT_TARGETS_DEFAULT_VALUE,
+    category = CoreProperties.CATEGORY_JAVA,
+    name = "Ant targets",
+    description = "Comma separated list of Ant targets for execution of tests.",
+    module = true,
+    project = true,
+    global = false)
+})
+public class JacocoConfiguration implements BatchExtension {
+
+  public static final String REPORT_PATH_PROPERTY = "sonar.groovy.jacoco.reportPath";
+  public static final String REPORT_PATH_DEFAULT_VALUE = "target/jacoco.exec";
+  public static final String IT_REPORT_PATH_PROPERTY = "sonar.groovy.jacoco.itReportPath";
+  public static final String IT_REPORT_PATH_DEFAULT_VALUE = "";
+  public static final String INCLUDES_PROPERTY = "sonar.groovy.jacoco.includes";
+  public static final String EXCLUDES_PROPERTY = "sonar.groovy.jacoco.excludes";
+
+  /**
+   * Hibernate uses Javassist to modify entity classes and without exclusion of such classes from JaCoCo exception might be thrown:
+   * <pre>
+   * Javassist Enhancement failed: org.sonar.api.profiles.Alert
+   * java.lang.VerifyError: (class: org/sonar/api/profiles/Alert_$$_javassist_3, method: <clinit> signature: ()V) Illegal local variable number
+   * </pre>
+   */
+  public static final String EXCLUDES_DEFAULT_VALUE = "*_javassist_*";
+  public static final String EXCLCLASSLOADER_PROPERTY = "sonar.groovy.jacoco.exclclassloader";
+  public static final String ANT_TARGETS_PROPERTY = "sonar.groovy.jacoco.antTargets";
+  public static final String ANT_TARGETS_DEFAULT_VALUE = "";
+
+  private Settings settings;
+  private JavaSettings javaSettings;
+  private JaCoCoAgentDownloader downloader;
+
+  public JacocoConfiguration(Settings settings, JaCoCoAgentDownloader downloader, JavaSettings javaSettings) {
+    this.settings = settings;
+    this.downloader = downloader;
+    this.javaSettings = javaSettings;
+  }
+
+  public boolean isEnabled(Project project) {
+    return Groovy.KEY.equals(project.getLanguageKey()) &&
+      project.getAnalysisType().isDynamic(true) &&
+      JaCoCoUtils.PLUGIN_KEY.equals(javaSettings.getEnabledCoveragePlugin());
+  }
+
+  public String getReportPath() {
+    return settings.getString(REPORT_PATH_PROPERTY);
+  }
+
+  public String getItReportPath() {
+    return settings.getString(IT_REPORT_PATH_PROPERTY);
+  }
+
+  public String getJvmArgument() {
+    AgentOptions options = new AgentOptions();
+    options.setDestfile(getReportPath());
+    String includes = Joiner.on(':').join(settings.getStringArray(INCLUDES_PROPERTY));
+    if (StringUtils.isNotBlank(includes)) {
+      options.setIncludes(includes);
+    }
+    String excludes = Joiner.on(':').join(settings.getStringArray(EXCLUDES_PROPERTY));
+    if (StringUtils.isNotBlank(excludes)) {
+      options.setExcludes(excludes);
+    }
+    String exclclassloader = Joiner.on(':').join(settings.getStringArray(EXCLCLASSLOADER_PROPERTY));
+    if (StringUtils.isNotBlank(exclclassloader)) {
+      options.setExclClassloader(exclclassloader);
+    }
+    return options.getVMArgument(downloader.getAgentJarFile());
+  }
+
+  public String[] getAntTargets() {
+    return settings.getStringArray(ANT_TARGETS_PROPERTY);
+  }
+
+  public String getExcludes() {
+    return settings.getString(EXCLUDES_PROPERTY);
+  }
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/JacocoMavenInitializer.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/JacocoMavenInitializer.java
@@ -1,0 +1,57 @@
+/*
+ * Sonar Groovy Plugin
+ * Copyright (C) 2010 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.groovy.jacoco;
+
+import org.sonar.api.batch.CoverageExtension;
+import org.sonar.api.batch.Initializer;
+import org.sonar.api.batch.SupportedEnvironment;
+import org.sonar.api.batch.maven.DependsUponMavenPlugin;
+import org.sonar.api.batch.maven.MavenPluginHandler;
+import org.sonar.api.resources.Java;
+import org.sonar.api.resources.Project;
+
+@SupportedEnvironment("maven")
+public class JacocoMavenInitializer extends Initializer implements CoverageExtension, DependsUponMavenPlugin {
+
+  private JaCoCoMavenPluginHandler handler;
+  private JacocoConfiguration configuration;
+
+  public JacocoMavenInitializer(JaCoCoMavenPluginHandler handler, JacocoConfiguration configuration) {
+    this.handler = handler;
+    this.configuration = configuration;
+  }
+
+  @Override
+  public boolean shouldExecuteOnProject(Project project) {
+    return configuration.isEnabled(project)
+      && project.getAnalysisType().equals(Project.AnalysisType.DYNAMIC)
+      && !project.getFileSystem().testFiles(Java.KEY).isEmpty();
+  }
+
+  @Override
+  public void execute(Project project) {
+    // nothing to do
+  }
+
+  public MavenPluginHandler getMavenPluginHandler(Project project) {
+    return handler;
+  }
+
+}

--- a/src/main/java/org/sonar/plugins/groovy/jacoco/package-info.java
+++ b/src/main/java/org/sonar/plugins/groovy/jacoco/package-info.java
@@ -17,36 +17,6 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
+@javax.annotation.ParametersAreNonnullByDefault
+package org.sonar.plugins.groovy.jacoco;
 
-package org.sonar.plugins.groovy.foundation;
-
-import net.sourceforge.pmd.cpd.Tokenizer;
-import org.sonar.api.batch.AbstractCpdMapping;
-import org.sonar.api.resources.Language;
-import org.sonar.api.resources.Resource;
-import org.sonar.plugins.groovy.jacoco.GroovyFile;
-
-import java.io.File;
-import java.util.List;
-
-public class GroovyCpdMapping extends AbstractCpdMapping {
-
-  private final Groovy language;
-
-  public GroovyCpdMapping(Groovy language) {
-    this.language = language;
-  }
-
-  public Resource createResource(java.io.File file, List<File> sourceDirs) {
-    return GroovyFile.fromIOFile(file, sourceDirs, false);
-  }
-
-  public Tokenizer getTokenizer() {
-    return new GroovyCpdTokenizer();
-  }
-
-  public Language getLanguage() {
-    return language;
-  }
-
-}

--- a/src/main/java/org/sonar/plugins/groovy/surefire/SurefireSensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/surefire/SurefireSensor.java
@@ -30,6 +30,7 @@ import org.sonar.api.resources.Project;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.api.resources.Resource;
 import org.sonar.plugins.groovy.foundation.Groovy;
+import org.sonar.plugins.groovy.jacoco.GroovyFile;
 import org.sonar.plugins.surefire.api.AbstractSurefireParser;
 import org.sonar.plugins.surefire.api.SurefireUtils;
 
@@ -62,8 +63,7 @@ public class SurefireSensor implements Sensor {
     @Override
     protected Resource<?> getUnitTestResource(String classKey) {
       String filename = classKey.replace('.', '/') + ".groovy";
-      org.sonar.api.resources.File sonarFile = new org.sonar.api.resources.File(filename);
-      sonarFile.setQualifier(Qualifiers.UNIT_TEST_FILE);
+      GroovyFile sonarFile = new GroovyFile(filename, true);
       return sonarFile;
     }
   };

--- a/src/main/java/org/sonar/plugins/groovy/surefire/SurefireSensor.java
+++ b/src/main/java/org/sonar/plugins/groovy/surefire/SurefireSensor.java
@@ -62,10 +62,11 @@ public class SurefireSensor implements Sensor {
   private static final AbstractSurefireParser SUREFIRE_PARSER = new AbstractSurefireParser() {
     @Override
     protected Resource<?> getUnitTestResource(String classKey) {
-      String filename = classKey.replace('.', '/') + ".groovy";
-      GroovyFile sonarFile = new GroovyFile(filename, true);
+      //String filename = classKey.replace('.', '/') + ".groovy";
+      GroovyFile sonarFile = new GroovyFile(classKey, true);
       return sonarFile;
     }
+
   };
 
   @Override

--- a/src/main/resources/org/sonar/plugins/groovy/rules.xml
+++ b/src/main/resources/org/sonar/plugins/groovy/rules.xml
@@ -2010,4 +2010,10 @@
     <description><![CDATA[Instead of nested collect{}-calls use collectNested{}]]></description>
   </rule>
 
+  <rule key="org.codenarc.rule.formatting.PublicMethodJavadocRule" priority="MAJOR">
+      <name><![CDATA[Public Method Javadoc]]></name>
+      <configKey><![CDATA[PublicMethodJavadoc]]></configKey>
+      <description><![CDATA[Public methods must have javadoc comments.]]></description>
+  </rule>
+
 </rules>

--- a/src/test/java/org/sonar/plugins/groovy/GroovyPluginTest.java
+++ b/src/test/java/org/sonar/plugins/groovy/GroovyPluginTest.java
@@ -28,7 +28,7 @@ public class GroovyPluginTest {
 
   @Test
   public void testExtensions() {
-    assertThat(new GroovyPlugin().getExtensions()).hasSize(14);
+    assertThat(new GroovyPlugin().getExtensions()).hasSize(22);
   }
 
 }

--- a/src/test/java/org/sonar/plugins/groovy/GroovySensorTest.java
+++ b/src/test/java/org/sonar/plugins/groovy/GroovySensorTest.java
@@ -28,6 +28,7 @@ import org.sonar.api.resources.Project;
 import org.sonar.api.resources.ProjectFileSystem;
 import org.sonar.api.test.IsMeasure;
 import org.sonar.plugins.groovy.foundation.Groovy;
+import org.sonar.plugins.groovy.jacoco.GroovyFile;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -71,7 +72,7 @@ public class GroovySensorTest {
 
     sensor.analyse(project, context);
 
-    File sonarFile = File.fromIOFile(new java.io.File(sourceDir, "Greeting.groovy"), sourceDirs);
+    GroovyFile sonarFile = GroovyFile.fromIOFile(new java.io.File(sourceDir, "Greeting.groovy"), sourceDirs, false);
     verify(context).saveMeasure(sonarFile, CoreMetrics.FILES, 1.0);
     verify(context).saveMeasure(sonarFile, CoreMetrics.CLASSES, 2.0);
     verify(context).saveMeasure(sonarFile, CoreMetrics.FUNCTIONS, 2.0);

--- a/src/test/java/org/sonar/plugins/groovy/GroovySensorTest.java
+++ b/src/test/java/org/sonar/plugins/groovy/GroovySensorTest.java
@@ -51,9 +51,9 @@ public class GroovySensorTest {
   }
 
   @Test
-  public void should_not_execute_on_java_project() {
+  public void should_not_execute_on_groovy_project() {
     Project project = mock(Project.class);
-    when(project.getLanguageKey()).thenReturn("java");
+    when(project.getLanguageKey()).thenReturn(Groovy.KEY);
     assertThat(sensor.shouldExecuteOnProject(project)).isFalse();
   }
 

--- a/src/test/java/org/sonar/plugins/groovy/cobertura/CoberturaSensorTest.java
+++ b/src/test/java/org/sonar/plugins/groovy/cobertura/CoberturaSensorTest.java
@@ -72,9 +72,9 @@ public class CoberturaSensorTest {
   }
 
   @Test
-  public void should_not_execute_on_java_project() {
+  public void should_not_execute_on_groovy_project() {
     Project project = mock(Project.class);
-    when(project.getLanguageKey()).thenReturn("java");
+    when(project.getLanguageKey()).thenReturn(Groovy.KEY);
     when(project.getAnalysisType()).thenReturn(Project.AnalysisType.DYNAMIC);
     assertThat(sensor.shouldExecuteOnProject(project)).isFalse();
   }

--- a/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcRuleRepositoryTest.java
+++ b/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcRuleRepositoryTest.java
@@ -30,7 +30,7 @@ public class CodeNarcRuleRepositoryTest {
   @Test
   public void test() {
     CodeNarcRuleRepository repo = new CodeNarcRuleRepository(new XMLRuleParser());
-    assertThat(repo.createRules().size()).isEqualTo(286);
+    assertThat(repo.createRules().size()).isEqualTo(287);
   }
 
 }

--- a/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensorTest.java
+++ b/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcSensorTest.java
@@ -74,9 +74,9 @@ public class CodeNarcSensorTest {
   }
 
   @Test
-  public void should_not_execute_on_java_project() {
+  public void should_not_execute_on_groovy_project() {
     Project project = mock(Project.class);
-    when(project.getLanguageKey()).thenReturn("java");
+    when(project.getLanguageKey()).thenReturn(Groovy.KEY);
     assertThat(sensor.shouldExecuteOnProject(project)).isFalse();
   }
 

--- a/src/test/java/org/sonar/plugins/groovy/surefire/SurefireSensorTest.java
+++ b/src/test/java/org/sonar/plugins/groovy/surefire/SurefireSensorTest.java
@@ -51,9 +51,9 @@ public class SurefireSensorTest {
   }
 
   @Test
-  public void should_not_execute_on_java_project() {
+  public void should_not_execute_on_groovy_project() {
     Project project = mock(Project.class);
-    when(project.getLanguageKey()).thenReturn("java");
+    when(project.getLanguageKey()).thenReturn(Groovy.KEY);
     when(project.getAnalysisType()).thenReturn(Project.AnalysisType.DYNAMIC);
     assertThat(sensor.shouldExecuteOnProject(project)).isFalse();
   }


### PR DESCRIPTION
Standing on the shoulders of the java-jacoco sonar plugin, a quick implementation of groovy-jacoco support for sonar. Works for both unit and integration tests.