### PR TITLE
SONARGROOV-35 fixed: Sqale mapping is not loaded in rules definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.codehaus.sonar.sslr-squid-bridge</groupId>
-        <artifactId>sslr-squid-bridge</artifactId>
-        <version>2.7-SNAPSHOT</version>
-      </dependency>        
-      <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy</artifactId>
         <version>${groovy.version}</version>
@@ -177,6 +172,12 @@
       <artifactId>fest-assert</artifactId>
       <version>1.4</version>
       <scope>test</scope>
+    </dependency>
+    <!-- needed for Sqale -->
+    <dependency>
+      <groupId>org.codehaus.sonar.sslr-squid-bridge</groupId>
+      <artifactId>sslr-squid-bridge</artifactId>
+      <version>2.6</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.codehaus.sonar.sslr-squid-bridge</groupId>
+        <artifactId>sslr-squid-bridge</artifactId>
+        <version>2.7-SNAPSHOT</version>
+      </dependency>        
+      <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy</artifactId>
         <version>${groovy.version}</version>
@@ -190,7 +195,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>10000000</maxsize>
+                  <maxsize>15000000</maxsize>
                   <minsize>8500000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>

--- a/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcRulesDefinition.java
+++ b/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcRulesDefinition.java
@@ -23,6 +23,7 @@ package org.sonar.plugins.groovy.codenarc;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.plugins.groovy.foundation.Groovy;
+import org.sonar.squidbridge.rules.SqaleXmlLoader;
 
 public class CodeNarcRulesDefinition implements RulesDefinition {
 
@@ -37,6 +38,7 @@ public class CodeNarcRulesDefinition implements RulesDefinition {
 
     RulesDefinitionXmlLoader ruleLoader = new RulesDefinitionXmlLoader();
     ruleLoader.load(repository, CodeNarcRulesDefinition.class.getResourceAsStream("/org/sonar/plugins/groovy/rules.xml"), "UTF-8");
+    SqaleXmlLoader.load(repository, "/com/sonar/sqale/groovy-model.xml");
     repository.done();
   }
 }


### PR DESCRIPTION
With the hints given in http://jira.sonarsource.com/browse/SONARGROOV-35 , I managed to add the loader for the Sqale mapping. The plugin compiles and runs. The technical debt is shown in days.

I had some slight problems with the org.sonar.squidbridge.rules.SqaleXmlLoader dependency. It is added to the pom the same way as in the findbugs plugin, but somehow it wasn't picket up by my build so I had to check out the project and add a project dependency in order to build it.

But I guess this should work by some maven magic with the normal travis build

I also had to raise the limit for the file size.

Hope this simple PR helps in some way :-)