### PR TITLE
SONARGROOV-18 Fix handling of rule parameters

### DIFF
--- a/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcProfileExporter.java
+++ b/src/main/java/org/sonar/plugins/groovy/codenarc/CodeNarcProfileExporter.java
@@ -20,8 +20,10 @@
 
 package org.sonar.plugins.groovy.codenarc;
 
+import org.apache.commons.lang.StringUtils;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.rules.ActiveRule;
+import org.sonar.api.rules.ActiveRuleParam;
 import org.sonar.api.utils.SonarException;
 
 import java.io.IOException;
@@ -74,6 +76,17 @@ public class CodeNarcProfileExporter {
       writer.append(AUTO_CLOSING_TAG);
     } else {
       writer.append("\">\n");
+      for (ActiveRuleParam activeRuleParam : activeRule.getActiveRuleParams()) {
+        String value = activeRuleParam.getValue();
+        String defaultValue = activeRuleParam.getRuleParam().getDefaultValue();
+        if (StringUtils.isNotBlank(value) && !value.equals(defaultValue)) {
+          writer.append("<property name=\"")
+            .append(activeRuleParam.getKey())
+            .append("\" value=\"")
+            .append(value)
+            .append(AUTO_CLOSING_TAG);
+        }
+      }
       writer.append("</rule>\n");
     }
   }

--- a/src/main/resources/org/sonar/plugins/groovy/rules.xml
+++ b/src/main/resources/org/sonar/plugins/groovy/rules.xml
@@ -3751,7 +3751,7 @@ for (int i = 0; i < 100; ++i) {
     <param>
       <key>specificationSuperclassNames</key>
       <description><![CDATA[Specifies one or more (comma-separated) class names that should be treated as Spock Specification superclasses. In other words, a class that extends a matching class name is considered a Spock Specification . The class names may optionally contain wildcards (*,?), e.g. "*Spec". ]]></description>
-      <defaultValue>"*Specification"</defaultValue>
+      <defaultValue>*Specification</defaultValue>
     </param>
   </rule>
 

--- a/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcProfileExporterTest.java
+++ b/src/test/java/org/sonar/plugins/groovy/codenarc/CodeNarcProfileExporterTest.java
@@ -65,7 +65,7 @@ public class CodeNarcProfileExporterTest {
   }
 
   @Test
-  public void shouldNotExportParameters() throws Exception {
+  public void shouldExportParameters() throws Exception {
     Rule rule = Rule.create(CodeNarcRulesDefinition.REPOSITORY_KEY, "org.codenarc.rule.size.ClassSizeRule", "Class Size");
     rule.createParameter("maxLines");
     profile.activateRule(rule, RulePriority.MAJOR).setParameter("maxLines", "20");
@@ -82,6 +82,19 @@ public class CodeNarcProfileExporterTest {
     Rule rule = Rule.create(CodeNarcRulesDefinition.REPOSITORY_KEY, "org.codenarc.rule.size.ClassSizeRule", "Class Size");
     rule.createParameter("maxLines");
     profile.activateRule(rule, RulePriority.MAJOR).setParameter("maxLines", null);
+
+    exporter.exportProfile(profile);
+
+    assertSimilarXml(
+      TestUtils.getResource("/org/sonar/plugins/groovy/codenarc/exportProfile/exportNullParameters.xml"),
+      writer.toString());
+  }
+
+  @Test
+  public void shouldNotExportParametersWithDefaultValue() throws Exception {
+    Rule rule = Rule.create(CodeNarcRulesDefinition.REPOSITORY_KEY, "org.codenarc.rule.size.ClassSizeRule", "Class Size");
+    rule.createParameter("maxLines").setDefaultValue("20");
+    profile.activateRule(rule, RulePriority.MAJOR).setParameter("maxLines", "20");
 
     exporter.exportProfile(profile);
 

--- a/src/test/resources/org/sonar/plugins/groovy/codenarc/exportProfile/exportParameters.xml
+++ b/src/test/resources/org/sonar/plugins/groovy/codenarc/exportProfile/exportParameters.xml
@@ -4,5 +4,6 @@
          xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
          xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
   <rule class="org.codenarc.rule.size.ClassSizeRule">
+    <property name="maxLines" value="20"/>
   </rule>
 </ruleset>


### PR DESCRIPTION
One of the parameter was badly formatted, plus default values such as `null` where also exported when creating the profile if the rule was activated with its default value.

Unfortunately, CodeNarc refuses `null` parameters for some of the rules, even when its corresponds to the default value. Consequently, parameters are now ignored when they corresponds to the default value.